### PR TITLE
Liquidation bonuses

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -22,7 +22,7 @@ export class RedeemCollateralEvent extends Struct({
   amountRedeemed: UInt64,
   vaultCollateralAmount: UInt64,
   vaultDebtAmount: UInt64,
-  price: UInt64,
+  minaPrice: UInt64,
 }) {}
 
 export class MintZkUsdEvent extends Struct({
@@ -30,7 +30,7 @@ export class MintZkUsdEvent extends Struct({
   amountMinted: UInt64,
   vaultCollateralAmount: UInt64,
   vaultDebtAmount: UInt64,
-  price: UInt64,
+  minaPrice: UInt64,
 }) {}
 
 export class BurnZkUsdEvent extends Struct({
@@ -45,18 +45,18 @@ export class LiquidateEvent extends Struct({
   liquidator: PublicKey,
   vaultCollateralLiquidated: UInt64,
   vaultDebtRepaid: UInt64,
-  price: UInt64,
+  minaPrice: UInt64,
 }) {}
 
-export class PriceUpdateEvent extends Struct({
+export class MinaPriceUpdateEvent extends Struct({
   newPrice: UInt64,
 }) {}
 
-export class FallbackPriceUpdateEvent extends Struct({
+export class FallbackMinaPriceUpdateEvent extends Struct({
   newPrice: UInt64,
 }) {}
 
-export class PriceSubmissionEvent extends Struct({
+export class MinaPriceSubmissionEvent extends Struct({
   submitter: PublicKey,
   price: UInt64,
   oracleFee: UInt64,

--- a/src/tests/price-feed/price-retrieval.test.ts
+++ b/src/tests/price-feed/price-retrieval.test.ts
@@ -14,28 +14,28 @@ describe('zkUSD Price Feed Oracle Price Retrieval Test Suite', () => {
 
   it('should retrieve the even price if we are on an even block', async () => {
     testHelper.Local.setBlockchainLength(UInt32.from(2));
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_52_CENT);
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_48_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_52_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_48_CENT);
 
     //odd should be 52 cent, even should be 48 cent
 
     testHelper.Local.setBlockchainLength(UInt32.from(4));
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
 
     assert.strictEqual(price.toString(), TestAmounts.PRICE_48_CENT.toString());
   });
 
   it('should retrieve the odd price if we are on an odd block', async () => {
     testHelper.Local.setBlockchainLength(UInt32.from(2));
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_52_CENT);
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_48_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_52_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_48_CENT);
 
     //odd should be 52 cent, even should be 48 cent
 
     testHelper.Local.setBlockchainLength(UInt32.from(4));
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
 
     assert.strictEqual(price.toString(), TestAmounts.PRICE_48_CENT.toString());
   });

--- a/src/tests/price-feed/price-settlement.test.ts
+++ b/src/tests/price-feed/price-settlement.test.ts
@@ -1,8 +1,6 @@
-import { AccountUpdate, Mina, PrivateKey, UInt32, UInt64 } from 'o1js';
+import { Mina, UInt32, UInt64 } from 'o1js';
 import { TestAmounts, TestHelper } from '../test-helper.js';
 import { ZkUsdEngine } from '../../zkusd-engine.js';
-import { OracleWhitelist } from '../../types.js';
-import { ZkUsdMasterOracle } from '../../zkusd-master-oracle.js';
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 
@@ -16,9 +14,9 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
   });
 
   it('should settle the correct price', async () => {
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_25_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_25_CENT);
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
 
     assert.strictEqual(price.toString(), TestAmounts.PRICE_25_CENT.toString());
   });
@@ -37,9 +35,9 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
 
   it('should eventually settle odd price, 3 blocks later, if we are on an odd block', async () => {
     testHelper.Local.setBlockchainLength(UInt32.from(1));
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_50_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_50_CENT);
 
-    const oddPrice = await testHelper.engine.contract.priceOddBlock.fetch();
+    const oddPrice = await testHelper.engine.contract.minaPriceOddBlock.fetch();
 
     assert.strictEqual(
       oddPrice?.toString(),
@@ -49,9 +47,9 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
 
   it('should eventually settle even price, 3 blocks later, if we are on an even block', async () => {
     testHelper.Local.setBlockchainLength(UInt32.from(2));
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_52_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_52_CENT);
 
-    const evenPrice = await testHelper.engine.contract.priceEvenBlock.fetch();
+    const evenPrice = await testHelper.engine.contract.minaPriceEvenBlock.fetch();
 
     assert.strictEqual(
       evenPrice?.toString(),
@@ -90,7 +88,7 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
       testHelper.Local.getNetworkState().blockchainLength.add(1)
     );
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
 
     assert.strictEqual(price.toString(), TestAmounts.PRICE_2_USD.toString());
   });
@@ -141,7 +139,7 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
       testHelper.Local.getNetworkState().blockchainLength.add(1)
     );
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
     // Should return middle price (50 cents)
     assert.strictEqual(price.toString(), medianPrice.toString());
   });
@@ -201,7 +199,7 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
       testHelper.Local.getNetworkState().blockchainLength.add(1)
     );
 
-    const priceBeforeSettlement = await testHelper.engine.contract.getPrice();
+    const priceBeforeSettlement = await testHelper.engine.contract.getMinaPrice();
     assert.strictEqual(
       priceBeforeSettlement.toString(),
       TestAmounts.PRICE_52_CENT.add(TestAmounts.PRICE_2_USD)
@@ -255,7 +253,7 @@ describe('zkUSD Price Feed Oracle Price Settlement Test Suite', () => {
       testHelper.Local.getNetworkState().blockchainLength.add(1)
     );
 
-    const price = await testHelper.engine.contract.getPrice();
+    const price = await testHelper.engine.contract.getMinaPrice();
     const expectedMedian = UInt64.from(0.515 * 1e9); // 0.515 USD
     assert.strictEqual(price.toString(), expectedMedian.toString());
   });

--- a/src/tests/test-helper.ts
+++ b/src/tests/test-helper.ts
@@ -1,22 +1,18 @@
 import {
   Mina,
   PrivateKey,
-  SmartContract,
   PublicKey,
   AccountUpdate,
   UInt8,
   Bool,
   Field,
   UInt64,
-  Experimental,
   UInt32,
 } from 'o1js';
-import { OracleWhitelist, ProtocolData } from '../types.js';
+import { OracleWhitelist } from '../types.js';
 import { ZkUsdEngine, ZkUsdEngineDeployProps } from '../zkusd-engine.js';
 import { ZkUsdVault } from '../zkusd-vault.js';
 import {
-  FungibleToken,
-  FungibleTokenAdminBase,
   FungibleTokenContract,
 } from '@minatokens/token';
 import { ZkUsdMasterOracle } from '../zkusd-master-oracle.js';
@@ -374,7 +370,7 @@ export class TestHelper {
     await this.transaction(this.deployer, async () => {
       AccountUpdate.fundNewAccount(this.deployer, 8);
       const au = AccountUpdate.createSigned(this.deployer);
-      for (const [name, oracle] of Object.entries(this.oracles)) {
+      for (const [_name, oracle] of Object.entries(this.oracles)) {
         au.send({
           to: oracle.publicKey,
           amount: TestAmounts.COLLATERAL_50_MINA,
@@ -426,13 +422,13 @@ export class TestHelper {
           );
         },
         {
-          extraSigners: [this.agents[name].vault.privateKey],
+          extraSigners: [this.agents[name].vault!.privateKey],
         }
       );
     }
   }
 
-  async updateOraclePrice(price: UInt64) {
+  async updateOracleMinaPrice(price: UInt64) {
     // Use the map to iterate over whitelisted oracles
     for (const [oracleName] of this.whitelistedOracles) {
       await this.transaction(this.oracles[oracleName], async () => {

--- a/src/tests/test-helper.ts
+++ b/src/tests/test-helper.ts
@@ -70,6 +70,7 @@ export class TestAmounts {
   // Price amounts
   static PRICE_0_USD = UInt64.from(0); // 0 USD
   static PRICE_25_CENT = UInt64.from(0.25e9); // 0.25 USD
+  static PRICE_40_CENT = UInt64.from(0.40e9); // 0.40 USD
   static PRICE_48_CENT = UInt64.from(0.48e9); // 0.48 USD
   static PRICE_49_CENT = UInt64.from(0.49e9); // 0.49 USD
   static PRICE_50_CENT = UInt64.from(0.5e9); // 0.50 USD

--- a/src/tests/vaults/health-factor.test.ts
+++ b/src/tests/vaults/health-factor.test.ts
@@ -1,4 +1,4 @@
-import { TestHelper, TestAmounts } from '../test-helper.js';
+import { TestHelper } from '../test-helper.js';
 import { UInt64 } from 'o1js';
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
@@ -198,7 +198,7 @@ describe('zkUSD Vault Health Factor Calculations Test Suite', () => {
         await testHelper.agents.alice.vault?.contract.collateralAmount.fetch();
       const debt =
         await testHelper.agents.alice.vault?.contract.debtAmount.fetch();
-      const price = await testHelper.engine.contract.getPrice();
+      const price = await testHelper.engine.contract.getMinaPrice();
 
       const healthFactor =
         await testHelper.engine.contract.getVaultHealthFactor(

--- a/src/tests/vaults/liquidation.test.ts
+++ b/src/tests/vaults/liquidation.test.ts
@@ -6,7 +6,7 @@ import { ProtocolData } from '../../types.js';
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 
-describe.only('zkUSD Vault Liquidation Test Suite', () => {
+describe('zkUSD Vault Liquidation Test Suite', () => {
   const testHelper = new TestHelper();
 
   before(async () => {
@@ -56,7 +56,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
         await testHelper.transaction(
           testHelper.agents.bob.account,
           async () => {
-            await testHelper.engine.contract.liquidate2(
+            await testHelper.engine.contract.liquidate(
               testHelper.agents.alice.vault!.publicKey
             );
           }
@@ -70,7 +70,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
 
   it('should fail liquidation if liquidator does not have sufficent zkUsd', async () => {
     //Price drops to 0.25
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_25_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_25_CENT);
 
     //Bob transfers 1 zkUSD to Charlie
     await testHelper.transaction(testHelper.agents.bob.account, async () => {
@@ -85,7 +85,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
       await testHelper.transaction(
         testHelper.agents.charlie.account,
         async () => {
-          await testHelper.engine.contract.liquidate2(
+          await testHelper.engine.contract.liquidate(
             testHelper.agents.alice.vault!.publicKey
           );
         }
@@ -105,7 +105,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
 
   //   await assert.rejects(async () => {
   //     await testHelper.transaction(testHelper.agents.bob.account, async () => {
-  //       await testHelper.engine.contract.liquidate2(
+  //       await testHelper.engine.contract.liquidate(
   //         testHelper.agents.alice.vault!.publicKey
   //       );
   //     });
@@ -115,7 +115,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
   it('should allow liquidation of vault if it is undercollateralized', async () => {
     //Price raises to 0.4
     const price = TestAmounts.PRICE_40_CENT;
-    await testHelper.updateOraclePrice(price);
+    await testHelper.updateOracleMinaPrice(price);
     // But the alice vault is still undercollateralized
 
     //Reset bobs permissions
@@ -144,7 +144,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
     );
 
     await testHelper.transaction(testHelper.agents.bob.account, async () => {
-      await testHelper.engine.contract.liquidate2(
+      await testHelper.engine.contract.liquidate(
         testHelper.agents.alice.vault!.publicKey
       );
     });
@@ -235,7 +235,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
 
   it('Should fail if the price feed is in emergency mode', async () => {
     // Drop price to make vault eligible for liquidation
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_2_USD);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_2_USD);
 
     // Set up Alice's vault with collateral and debt
     await testHelper.transaction(
@@ -259,7 +259,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
     );
 
     // Drop price to make vault eligible for liquidation
-    await testHelper.updateOraclePrice(TestAmounts.PRICE_25_CENT);
+    await testHelper.updateOracleMinaPrice(TestAmounts.PRICE_25_CENT);
 
     await testHelper.stopTheProtocol();
 
@@ -270,7 +270,7 @@ describe.only('zkUSD Vault Liquidation Test Suite', () => {
 
     await assert.rejects(async () => {
       await testHelper.transaction(testHelper.agents.bob.account, async () => {
-        await testHelper.engine.contract.liquidate2(
+        await testHelper.engine.contract.liquidate(
           testHelper.agents.charlie.vault!.publicKey
         );
       });

--- a/src/tests/vaults/liquidation.test.ts
+++ b/src/tests/vaults/liquidation.test.ts
@@ -1,12 +1,12 @@
 import { TestHelper, TestAmounts } from '../test-helper.js';
-import { AccountUpdate, Mina, Permissions } from 'o1js';
-import { ZkUsdVaultErrors } from '../../zkusd-vault.js';
+import { AccountUpdate, Field, Mina, Permissions, UInt64 } from 'o1js';
+import { ZkUsdVault, ZkUsdVaultErrors } from '../../zkusd-vault.js';
 import { ZkUsdEngineErrors } from '../../zkusd-engine.js';
 import { ProtocolData } from '../../types.js';
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
 
-describe('zkUSD Vault Liquidation Test Suite', () => {
+describe.only('zkUSD Vault Liquidation Test Suite', () => {
   const testHelper = new TestHelper();
 
   before(async () => {
@@ -93,26 +93,31 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     }, /Overflow/i);
   });
 
-  it('should fail liquidation if liquidator does not have receive permissions', async () => {
-    await testHelper.transaction(testHelper.agents.bob.account, async () => {
-      let au = AccountUpdate.create(testHelper.agents.bob.account);
-      let permissions = Permissions.default();
-      permissions.receive = Permissions.impossible();
-      au.account.permissions.set(permissions);
-      AccountUpdate.attachToTransaction(au);
-      au.requireSignature();
-    });
+  // it('should fail liquidation if liquidator does not have receive permissions', async () => {
+  //   await testHelper.transaction(testHelper.agents.bob.account, async () => {
+  //     let au = AccountUpdate.create(testHelper.agents.bob.account);
+  //     let permissions = Permissions.default();
+  //     permissions.receive = Permissions.impossible();
+  //     au.account.permissions.set(permissions);
+  //     AccountUpdate.attachToTransaction(au);
+  //     au.requireSignature();
+  //   });
 
-    await assert.rejects(async () => {
-      await testHelper.transaction(testHelper.agents.bob.account, async () => {
-        await testHelper.engine.contract.liquidate2(
-          testHelper.agents.alice.vault!.publicKey
-        );
-      });
-    });
-  });
+  //   await assert.rejects(async () => {
+  //     await testHelper.transaction(testHelper.agents.bob.account, async () => {
+  //       await testHelper.engine.contract.liquidate2(
+  //         testHelper.agents.alice.vault!.publicKey
+  //       );
+  //     });
+  //   });
+  // });
 
   it('should allow liquidation of vault if it is undercollateralized', async () => {
+    //Price raises to 0.4
+    const price = TestAmounts.PRICE_40_CENT;
+    await testHelper.updateOraclePrice(price);
+    // But the alice vault is still undercollateralized
+
     //Reset bobs permissions
     await testHelper.transaction(testHelper.agents.bob.account, async () => {
       let au = AccountUpdate.create(testHelper.agents.bob.account);
@@ -162,25 +167,45 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
       testHelper.agents.alice.account
     );
 
-    assert.deepStrictEqual(aliceVaultCollateralPostLiq, TestAmounts.ZERO);
-    assert.deepStrictEqual(aliceVaultDebtPostLiq, TestAmounts.ZERO);
+    assert.equal(
+      ZkUsdVault.LIQUIDATION_BONUS_RATIO.equals(Field.from(110)).toBoolean(),
+      true);
+
+    assert.deepStrictEqual(aliceVaultCollateralPostLiq, TestAmounts.ZERO, "Alice vault's collateral should be 0 after liquidation");
+    assert.deepStrictEqual(aliceVaultDebtPostLiq, TestAmounts.ZERO, "Alice vault's debt should be 0 after liquidation");
+
+    const bobdiff = bobMinaBalancePostLiq.sub(bobMinaBalancePreLiq);
+    const aliceDiff = aliceMinaBalancePostLiq.sub(aliceMinaBalancePreLiq);
+
+    // total collateral returned should be equal to the collateral in the vault preliq
+    assert.deepStrictEqual(bobdiff.add(aliceDiff), aliceVaultCollateralPreLiq, "Total collateral returned should be equal to the collateral in the vault preliq");
+
+    const ratio = UInt64.Unsafe.fromField(ZkUsdVault.LIQUIDATION_BONUS_RATIO);
+
+    // bob collateral should be equal to the debt value of collateral + liquidation bonus,
+    // which is defined by ratio, e.g. ratio 110 is 10% bonus
+    const collateralValue =  aliceVaultDebtPreLiq!.value.mul(Field.from(1e9)).div(price.value);
+    const valueWithLiquidationBonus = UInt64.Unsafe.fromField(collateralValue.mul(ratio.value).div(Field.from(100)));
+
     assert.deepStrictEqual(
       bobZkUsdBalancePostLiq,
-      bobZkUsdBalancePreLiq.sub(aliceVaultDebtPreLiq!)
+      bobZkUsdBalancePreLiq.sub(aliceVaultDebtPreLiq!),
+      "Bob should have the paid debt remmoved from his zkUSD balance"
     );
     assert.deepStrictEqual(
       bobMinaBalancePostLiq,
-      bobMinaBalancePreLiq.add(aliceVaultCollateralPreLiq!)
+      bobMinaBalancePreLiq.add(valueWithLiquidationBonus),
+      "Bob should have received bought collateral plus the liquidation bonus"
     );
-    assert.deepStrictEqual(aliceZkUsdBalancePostLiq, aliceZkUsdBalancePreLiq);
-    assert.deepStrictEqual(aliceMinaBalancePostLiq, aliceMinaBalancePreLiq);
+    assert.deepStrictEqual(aliceZkUsdBalancePostLiq, aliceZkUsdBalancePreLiq,
+                          "Alice private zkUSD should not have changed.");
   });
 
-  it('should emit the Liquidate2 event', async () => {
+  it('should emit the Liquidate event', async () => {
     const contractEvents = await testHelper.engine.contract.fetchEvents();
     const latestEvent = contractEvents[0];
 
-    assert.strictEqual(latestEvent.type, 'Liquidate2');
+    assert.strictEqual(latestEvent.type, 'Liquidate');
     assert.deepStrictEqual(
       // @ts-ignore
       latestEvent.event.data.vaultAddress,
@@ -193,7 +218,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     );
     assert.deepStrictEqual(
       // @ts-ignore
-      latestEvent.event.data.vaultCollateralLiquidate2d,
+      latestEvent.event.data.vaultCollateralLiquidated,
       TestAmounts.COLLATERAL_100_MINA
     );
     assert.deepStrictEqual(
@@ -204,7 +229,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     assert.deepStrictEqual(
       // @ts-ignore
       latestEvent.event.data.price,
-      TestAmounts.PRICE_25_CENT
+      TestAmounts.PRICE_40_CENT
     );
   });
 

--- a/src/tests/vaults/liquidation.test.ts
+++ b/src/tests/vaults/liquidation.test.ts
@@ -1,7 +1,7 @@
 import { TestHelper, TestAmounts } from '../test-helper.js';
-import { AccountUpdate, Mina, Permissions, UInt64 } from 'o1js';
-import { ZkUsdVault, ZkUsdVaultErrors } from '../../zkusd-vault.js';
-import { ZkUsdEngine, ZkUsdEngineErrors } from '../../zkusd-engine.js';
+import { AccountUpdate, Mina, Permissions } from 'o1js';
+import { ZkUsdVaultErrors } from '../../zkusd-vault.js';
+import { ZkUsdEngineErrors } from '../../zkusd-engine.js';
 import { ProtocolData } from '../../types.js';
 import { describe, it, before } from 'node:test';
 import assert from 'node:assert';
@@ -56,7 +56,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
         await testHelper.transaction(
           testHelper.agents.bob.account,
           async () => {
-            await testHelper.engine.contract.liquidate(
+            await testHelper.engine.contract.liquidate2(
               testHelper.agents.alice.vault!.publicKey
             );
           }
@@ -85,7 +85,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
       await testHelper.transaction(
         testHelper.agents.charlie.account,
         async () => {
-          await testHelper.engine.contract.liquidate(
+          await testHelper.engine.contract.liquidate2(
             testHelper.agents.alice.vault!.publicKey
           );
         }
@@ -105,7 +105,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
 
     await assert.rejects(async () => {
       await testHelper.transaction(testHelper.agents.bob.account, async () => {
-        await testHelper.engine.contract.liquidate(
+        await testHelper.engine.contract.liquidate2(
           testHelper.agents.alice.vault!.publicKey
         );
       });
@@ -139,7 +139,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     );
 
     await testHelper.transaction(testHelper.agents.bob.account, async () => {
-      await testHelper.engine.contract.liquidate(
+      await testHelper.engine.contract.liquidate2(
         testHelper.agents.alice.vault!.publicKey
       );
     });
@@ -176,11 +176,11 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     assert.deepStrictEqual(aliceMinaBalancePostLiq, aliceMinaBalancePreLiq);
   });
 
-  it('should emit the Liquidate event', async () => {
+  it('should emit the Liquidate2 event', async () => {
     const contractEvents = await testHelper.engine.contract.fetchEvents();
     const latestEvent = contractEvents[0];
 
-    assert.strictEqual(latestEvent.type, 'Liquidate');
+    assert.strictEqual(latestEvent.type, 'Liquidate2');
     assert.deepStrictEqual(
       // @ts-ignore
       latestEvent.event.data.vaultAddress,
@@ -193,7 +193,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
     );
     assert.deepStrictEqual(
       // @ts-ignore
-      latestEvent.event.data.vaultCollateralLiquidated,
+      latestEvent.event.data.vaultCollateralLiquidate2d,
       TestAmounts.COLLATERAL_100_MINA
     );
     assert.deepStrictEqual(
@@ -245,7 +245,7 @@ describe('zkUSD Vault Liquidation Test Suite', () => {
 
     await assert.rejects(async () => {
       await testHelper.transaction(testHelper.agents.bob.account, async () => {
-        await testHelper.engine.contract.liquidate(
+        await testHelper.engine.contract.liquidate2(
           testHelper.agents.charlie.vault!.publicKey
         );
       });

--- a/src/tests/vaults/mint.test.ts
+++ b/src/tests/vaults/mint.test.ts
@@ -182,7 +182,7 @@ describe('zkUSD Vault Mint Test Suite', () => {
         testHelper.agents.alice.vault?.contract.calculateHealthFactor(
           initialCollateral!,
           currentDebt!.add(TestAmounts.DEBT_1_ZKUSD),
-          await testHelper.engine.contract.getPrice()
+          await testHelper.engine.contract.getMinaPrice()
         );
 
       // Only mint if health factor would remain above minimum
@@ -204,7 +204,7 @@ describe('zkUSD Vault Mint Test Suite', () => {
       testHelper.agents.alice.vault?.contract.calculateHealthFactor(
         initialCollateral!,
         currentDebt!,
-        await testHelper.engine.contract.getPrice()
+        await testHelper.engine.contract.getMinaPrice()
       );
 
     assert.strictEqual(

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,3 +107,10 @@ export class VaultState extends Struct({
   debtAmount: UInt64,
   owner: PublicKey,
 }) {}
+
+
+export class LiquidationResults extends Struct({
+  oldVaultState: VaultState,
+  liquidatorCollateral: UInt64,
+  vaultOwnerCollateral: UInt64,
+}) {}

--- a/src/zkusd-engine.ts
+++ b/src/zkusd-engine.ts
@@ -599,7 +599,9 @@ export class ZkUsdEngine
     const vault = new ZkUsdVault(vaultAddress, this.deriveTokenId());
 
     //Get the owner of the zkUSD
-    const owner = this.sender.getAndRequireSignature();
+    // we have sender signature from zkUSD.burn
+    // TODO verify
+    const owner = this.sender.getUnconstrained();
 
     //Get the zkUSD token contract
     const zkUSD = new ZkUsdEngine.FungibleToken(
@@ -640,8 +642,10 @@ export class ZkUsdEngine
       ZkUsdEngine.ZKUSD_TOKEN_ADDRESS
     );
 
-    //Get the liquidator
-    const liquidator = this.sender.getAndRequireSignature();
+    // Get the liquidator
+    // NOTE. we have sender signature from zkUSD.burn
+    //       so we can use unconstrained
+    const liquidator = this.sender.getUnconstrained();
 
     //Get the price
     const price = await this.getPrice();
@@ -692,8 +696,10 @@ export class ZkUsdEngine
       ZkUsdEngine.ZKUSD_TOKEN_ADDRESS
     );
 
-    //Get the liquidator
-    const liquidator = this.sender.getAndRequireSignature();
+    // Get the liquidator
+    // NOTE. we have sender signature from zkUSD.burn
+    //       so we can use unconstrained
+    const liquidator = this.sender.getUnconstrained();
 
     // Get the vault owner
     const vaultOwner = vault.owner.getAndRequireEquals();
@@ -703,6 +709,8 @@ export class ZkUsdEngine
 
     const { oldVaultState, liquidatorCollateral, vaultOwnerCollateral}
       = await vault.liquidate2(price);
+
+    oldVaultState.collateralAmount.assertEquals(liquidatorCollateral.add(vaultOwnerCollateral));
 
     //Burn the debt from the liquidator
     await zkUSD.burn(liquidator, oldVaultState.debtAmount);

--- a/src/zkusd-master-oracle.ts
+++ b/src/zkusd-master-oracle.ts
@@ -42,7 +42,7 @@ export class ZkUsdMasterOracle extends SmartContract {
       .assertTrue(ZkUsdMasterOracleErrors.AMOUNT_ZERO);
 
     //Update the fallback price based on the current block
-    const { evenPrice, oddPrice } = this.updateBlockPrices(
+    const { evenPrice, oddPrice } = this.updateBlockMinaPrices(
       isOddBlock,
       price,
       currentPrices
@@ -112,7 +112,7 @@ export class ZkUsdMasterOracle extends SmartContract {
    * @param   currentPrices The current prices
    * @returns The updated prices
    */
-  private updateBlockPrices(
+  private updateBlockMinaPrices(
     isOddBlock: Bool,
     newPrice: UInt64,
     currentPrices: { even: UInt64; odd: UInt64 }


### PR DESCRIPTION
This PR updates the liquidation logic.
Previously, the liquidator would receive all the collateral from the vault after repaying the vault's debt.
With this update, the liquidator will receive collateral equivalent to the value of the debt, plus a liquidation bonus defined in zkVault as LIQUIDATION_BONUS_RATIO. The remaining collateral will be returned to the vault owner.

Additionally, this PR transitions from referring to the MINA/USD price in the system simply as "the price"—which was sometimes ambiguous at first glance—to explicitly calling it "the MINA price."